### PR TITLE
cupy 14.1.1 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -3,5 +3,3 @@ build_parameters:
   - "--suppress-variables"
   - "--skip-existing"
 
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314: yes

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,6 @@
+# We don`t have cusparselt for cuda 12.9, so it is disabled:
+# https://github.com/AnacondaRecipes/cusparselt-feedstock/blob/main/recipe/conda_build_config.yaml#L4
+
 gpu_variant:
   - cuda-13
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,10 @@
+gpu_variant:
+  - cuda-13
+
+cuda_compiler_version:
+  - 13
+
+zip_keys:
+  -
+    - gpu_variant
+    - cuda_compiler_version

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,7 @@
 {% set name = "cupy" %}
-{% set version = "14.0.1" %}
-{% set sha256 = "4b673ab2d8b2329abe7ae0a7ae6159656044a8eecca56cf0b834b7c907063205" %}
-{% set number = 1 %}
+{% set version = "14.1.1" %}
 
 {% set target_name = "x86_64-linux" %}  # [linux64]
-{% set target_name = "ppc64le-linux" %}  # [ppc64le]
 {% set target_name = "sbsa-linux" %}  # [aarch64]
 {% set target_name = "x64" %}  # [win]
 
@@ -17,15 +14,15 @@
 
 
 package:
-  name: {{ name|lower }}-split
+  name: {{ name }}-split
   version: {{ version }}
 
 source:
-  - url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: {{ sha256 }}
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 3d4d193a5b028e1823d1d44fe6268364d8fb76c3793ad4e28e1427c56ceb2f80
 
 build:
-  number: {{ number }}
+  number: 0
   skip: true  # [(py<310) or osx]
 
 requirements:
@@ -60,7 +57,7 @@ outputs:
       source_files:
         - tests
     about:
-      home: https://cupy.dev/
+      home: https://cupy.dev
       license: MIT
       license_family: MIT
       license_file: LICENSE
@@ -69,8 +66,8 @@ outputs:
       description: |
         CuPy is an open-source array library for GPU-accelerated computing with Python.
         It provides GPU versions of many NumPy and SciPy functions.
-      dev_url: https://github.com/cupy/cupy/
-      doc_url: https://docs.cupy.dev/en/stable/
+      dev_url: https://github.com/cupy/cupy
+      doc_url: https://docs.cupy.dev
 
   - name: cupy-core
     version: {{ version }}
@@ -134,8 +131,8 @@ outputs:
         - pip
         - wheel
         - setuptools >=77
-        - cython >=3.1,<3.2
-        - numpy 2.*
+        - cython >=3.2,<3.3
+        - numpy {{ numpy }}
         - cuda-version {{ cuda_compiler_version }}
         - cuda-driver-dev  # [linux]
         - cuda-cudart-dev
@@ -148,11 +145,11 @@ outputs:
         - libcurand-dev
         - libcusolver-dev
         - libcusparse-dev
-        - nccl ~=2.17           # [linux]
-        - cutensor ~=2.0
+        - nccl >=2.17,<3.0  # [linux]
+        - cutensor >=2.0,<3.0
       run:
         - python
-        - cuda-pathfinder >=1.3.3,<2.0a0
+        - cuda-pathfinder >=1.3.4,<2.0a0
         - numpy >=2.0,<2.6
       run_constrained:
         # we move these here so that cupy-core can be installed in CPU-only envs
@@ -163,7 +160,7 @@ outputs:
         - {{ pin_compatible('libcurand', min_pin='x', max_pin='x') }}
         - {{ pin_compatible('libcusolver', min_pin='x', max_pin='x') }}
         - {{ pin_compatible('libcusparse', min_pin='x', max_pin='x') }}
-        - scipy >=1.10,<1.17
+        - scipy >=1.14,<1.17
         - optuna >=2.0
         # unbounded: __cuda gates GPU presence; cuda-version handles the version
         - __cuda
@@ -178,7 +175,7 @@ outputs:
       commands:
         - pip check
     about:
-      home: https://cupy.dev/
+      home: https://cupy.dev
       license: MIT
       license_family: MIT
       license_file: LICENSE
@@ -187,18 +184,18 @@ outputs:
       description: |
         This is the CuPy core package without any dependencies on the CUDA libraries, suitable for
         deployment under resource constraint. You need to install the needed dependencies explicitly.
-      dev_url: https://github.com/cupy/cupy/
-      doc_url: https://docs.cupy.dev/en/stable/
+      dev_url: https://github.com/cupy/cupy
+      doc_url: https://docs.cupy.dev
 
 about:
-  home: https://cupy.dev/
+  home: https://cupy.dev
   license: MIT
   license_family: MIT
   license_file: LICENSE
   summary: |
     CuPy: NumPy & SciPy for GPU
-  dev_url: https://github.com/cupy/cupy/
-  doc_url: https://docs.cupy.dev/en/stable/
+  dev_url: https://github.com/cupy/cupy
+  doc_url: https://docs.cupy.dev
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,8 +32,6 @@ requirements:
 outputs:
   - name: cupy
     version: {{ version }}
-    build:
-      number: {{ number }}
     requirements:
       host:
         - python
@@ -72,7 +70,6 @@ outputs:
   - name: cupy-core
     version: {{ version }}
     build:
-      number: {{ number }}
       script_env:
         # To avoid memory usage warnings on CI, reduce parallelism of CuPy builds.
         - CUPY_NUM_BUILD_JOBS=1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -113,6 +113,7 @@ outputs:
         - libcurand-dev
         - libcusolver-dev
         - libcusparse-dev
+        - cuda-nvcc-dev
       ignore_run_exports:
         # optional dependencies
         - nccl        # [linux]
@@ -131,6 +132,8 @@ outputs:
         - cython >=3.2,<3.3
         - numpy {{ numpy }}
         - cuda-version {{ cuda_compiler_version }}
+        # can't find libcufilt
+        - cuda-nvcc {{ cuda_compiler_version }}
         - cuda-driver-dev  # [linux]
         - cuda-cudart-dev
         - cuda-cudart-static

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -134,7 +134,7 @@ outputs:
         - numpy {{ numpy }}
         - cuda-version {{ cuda_compiler_version }}
         # can't find libcufilt
-        - cuda-nvcc {{ cuda_compiler_version }}
+        - cuda-cuxxfilt
         # can't find cusparseLt.h
         - cusparselt-dev
         - cuda-driver-dev  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ package:
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 3d4d193a5b028e1823d1d44fe6268364d8fb76c3793ad4e28e1427c56ceb2f80
-  pathces:
+  patches:
     # Fixes a compile-time redefinition conflict where cupy's own SpGEAM stub
     # typedefs collide with CUDA 13's cusparse.h, which now declares these
     # natively as a real enum/struct instead of leaving them undefined; the fix

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@
 {% set PYTHON = "$PREFIX/bin/python" %}  # [linux]
 {% set PYTHON = "%PREFIX%\\python" %}  # [win]
 
-
 package:
   name: {{ name }}-split
   version: {{ version }}
@@ -20,6 +19,14 @@ package:
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 3d4d193a5b028e1823d1d44fe6268364d8fb76c3793ad4e28e1427c56ceb2f80
+  pathces:
+    # Fixes a compile-time redefinition conflict where cupy's own SpGEAM stub
+    # typedefs collide with CUDA 13's cusparse.h, which now declares these
+    # natively as a real enum/struct instead of leaving them undefined; the fix
+    # gates the stub behind a Cython-level CUPY_CUDA_VERSION check (rather than
+    # the original #ifndef, which failed to detect this both due to include
+    # ordering and because the CUDA 13 symbol is an enum value, not a macro).
+    - patches/0001-cusparse-spgeam-cuda13-guard.patch
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -114,6 +114,7 @@ outputs:
         - libcusolver-dev
         - libcusparse-dev
         - cuda-nvcc-dev
+        - libcusparselt-dev
       ignore_run_exports:
         # optional dependencies
         - nccl        # [linux]
@@ -134,6 +135,8 @@ outputs:
         - cuda-version {{ cuda_compiler_version }}
         # can't find libcufilt
         - cuda-nvcc {{ cuda_compiler_version }}
+        # can't find cusparseLt.h
+        - cusparselt-dev
         - cuda-driver-dev  # [linux]
         - cuda-cudart-dev
         - cuda-cudart-static

--- a/recipe/patches/0001-cusparse-spgeam-cuda13-guard.patch
+++ b/recipe/patches/0001-cusparse-spgeam-cuda13-guard.patch
@@ -1,0 +1,44 @@
+--- a/cupy_backends/cuda/libs/cusparse.pxd	2026-05-30 14:11:46.000000000 +0000
++++ b/cupy_backends/cuda/libs/cusparse.pxd	2026-07-30 10:22:44.404692265 +0000
+@@ -70,19 +70,28 @@
+     ctypedef int Csr2CscAlg 'cusparseCsr2CscAlg_t'
+ 
+ # TODO(eriknw): cuSPARSE--remove stubs when SpGEAM ships in a public release.
+-# The #ifndef guard auto-deactivates when the real header defines these.
+-cdef extern from *:
+-    """
+-    #ifndef CUSPARSE_SPGEAM_ALG_DEFAULT
+-    /* SpGEAM not in this cuSPARSE; provide opaque forward decls. */
+-    typedef void* cusparseSpGEAMDescr_t;
+-    typedef int cusparseSpGEAMAlg_t;
+-    #define CUSPARSE_SPGEAM_ALG_DEFAULT 0
+-    #define CUSPARSE_SPGEAM_ALG1 1
+-    #endif
+-    """
+-    ctypedef void* SpGEAMDescr 'cusparseSpGEAMDescr_t'
+-    ctypedef int SpGEAMAlg 'cusparseSpGEAMAlg_t'
++# NOTE: gated on CUPY_CUDA_VERSION (a Cython compile-time constant), not on a
++# C preprocessor #ifndef, because (a) this block is emitted by Cython before
++# cusparse.h is #included in the generated source, so any macro-presence
++# check here always sees an undefined macro regardless of CUDA version, and
++# (b) starting with CUDA 13's cusparse.h, CUSPARSE_SPGEAM_ALG_DEFAULT is an
++# enum value, not a #define, so #ifndef could never detect it anyway.
++IF CUPY_CUDA_VERSION < 13000:
++    cdef extern from *:
++        """
++        /* SpGEAM not in this cuSPARSE; provide opaque forward decls. */
++        typedef void* cusparseSpGEAMDescr_t;
++        typedef int cusparseSpGEAMAlg_t;
++        #define CUSPARSE_SPGEAM_ALG_DEFAULT 0
++        #define CUSPARSE_SPGEAM_ALG1 1
++        """
++        ctypedef void* SpGEAMDescr 'cusparseSpGEAMDescr_t'
++        ctypedef int SpGEAMAlg 'cusparseSpGEAMAlg_t'
++ELSE:
++    # cusparse.h (CUDA 13+) declares these natively; just alias them.
++    cdef extern from *:
++        ctypedef void* SpGEAMDescr 'cusparseSpGEAMDescr_t'
++        ctypedef int SpGEAMAlg 'cusparseSpGEAMAlg_t'
+ 
+ cpdef enum:
+     CUSPARSE_POINTER_MODE_HOST = 0


### PR DESCRIPTION
cupy 14.1.1 

**Destination channel:** Defaults

### Links

- [PKG-16039]
- dev_url:        https://github.com/cupy/cupy//tree/v14.1.1
- conda_forge:    https://github.com/conda-forge/cupy-feedstock
- pypi:           https://pypi.org/project/cupy/14.1.1
- pypi inspector: https://inspector.pypi.io/project/cupy/14.1.1

### Explanation of changes:

- new version number


[PKG-16039]: https://anaconda.atlassian.net/browse/PKG-16039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ